### PR TITLE
Add additional commented context around claim params

### DIFF
--- a/src/components/Claim.tsx
+++ b/src/components/Claim.tsx
@@ -21,8 +21,8 @@ export function Claim({ accountAddress }: { accountAddress: string }) {
     {
       args: [
         0, // assuming PricedMint module is index 0
-        [0],
-        [1],
+        [0], // tokenIds
+        [1], // mint amounts
         [],
         "0x"
       ],
@@ -30,7 +30,9 @@ export function Claim({ accountAddress }: { accountAddress: string }) {
     }
   );
 
-  const supplementalArgs = utils.defaultAbiCoder.encode(["uint", "uint"], [1, 1]);
+  // claim list module supplumental data args: [maxAmount, claimAmount]
+  const claimlistDataArgs = utils.defaultAbiCoder.encode(["uint", "uint"], [1, 1]);
+  
   const { write: claimClaimlist } = useContractWrite(
     {
       addressOrName: PASSPORT_CONTRACT_ADDRESS,
@@ -40,11 +42,11 @@ export function Claim({ accountAddress }: { accountAddress: string }) {
     {
       args: [
         1, // assuming ClaimList module is index 1
-        [0],
-        [1],
-        getClaimlistMerkleProof(CLAIMLIST_ADDRESSES, accountAddress, "1"),
-        supplementalArgs
-      ], // proof, maximum claim amount (as stored in merkle tree), claim amount on transaction
+        [0], // tokenIds
+        [1], // mint amounts
+        getClaimlistMerkleProof(CLAIMLIST_ADDRESSES, accountAddress, "1"), // proof
+        claimlistDataArgs // maximum claim amount (as stored in merkle tree), claim amount on transaction
+      ], 
       overrides: { value: MINT_PRICE }, // claim price
     }
   );

--- a/src/components/Claim.tsx
+++ b/src/components/Claim.tsx
@@ -21,7 +21,7 @@ export function Claim({ accountAddress }: { accountAddress: string }) {
     {
       args: [
         0, // assuming PricedMint module is index 0
-        [0], // tokenIds
+        [], // unused
         [1], // mint amounts
         [],
         "0x"
@@ -42,7 +42,7 @@ export function Claim({ accountAddress }: { accountAddress: string }) {
     {
       args: [
         1, // assuming ClaimList module is index 1
-        [0], // tokenIds
+        [], // unused
         [1], // mint amounts
         getClaimlistMerkleProof(CLAIMLIST_ADDRESSES, accountAddress, "1"), // proof
         claimlistDataArgs // maximum claim amount (as stored in merkle tree), claim amount on transaction


### PR DESCRIPTION
this PR adds additional comments around the `claim` function code, specifically around the parameters. 